### PR TITLE
Add prizes and sponsors sections to website

### DIFF
--- a/src/features/prizes-and-sponsors.css
+++ b/src/features/prizes-and-sponsors.css
@@ -1,0 +1,38 @@
+/* Prizes and Sponsors Section Styles */
+#prizes-sponsors, #sponsors {
+  padding: 50px 0;
+  background-color: #f9f9f9;
+}
+
+#prizes-sponsors h2, #sponsors h2 {
+  text-align: center;
+  font-size: 2rem;
+  margin-bottom: 30px;
+}
+
+.prizes-list, .sponsors-list {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+}
+
+.prize-item, .sponsor-item {
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  margin: 10px;
+  flex: 1 1 30%;
+}
+
+.prize-item h3 {
+  font-size: 1.5rem;
+  color: #333;
+}
+
+.sponsor-item img {
+  max-width: 100px;
+  height: auto;
+  margin: 0 auto;
+}

--- a/src/features/prizes-and-sponsors.html
+++ b/src/features/prizes-and-sponsors.html
@@ -1,0 +1,40 @@
+<!-- Prizes and Sponsors Section -->
+<section id="prizes-sponsors" class="prizes-sponsors-section">
+  <div class="container">
+    <h2>Prizes</h2>
+    <div class="prizes-list">
+      <div class="prize-item">
+        <h3>1st Place</h3>
+        <p>Cash prize: $10,000</p>
+        <p>Sponsored by XYZ Company</p>
+      </div>
+      <div class="prize-item">
+        <h3>2nd Place</h3>
+        <p>Cash prize: $5,000</p>
+        <p>Sponsored by ABC Corporation</p>
+      </div>
+      <div class="prize-item">
+        <h3>3rd Place</h3>
+        <p>Cash prize: $2,500</p>
+        <p>Sponsored by DEF Industries</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="sponsors" class="sponsors-section">
+  <div class="container">
+    <h2>Sponsors</h2>
+    <div class="sponsors-list">
+      <div class="sponsor-item">
+        <img src="/assets/img/ICPC_UCD.png" alt="ICPC UCD">
+      </div>
+      <div class="sponsor-item">
+        <img src="/assets/img/stormfaze.regular.webp" alt="Stormfaze">
+      </div>
+      <div class="sponsor-item">
+        <img src="/assets/img/acpc_pokemon.png" alt="ACPC Pokemon">
+      </div>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
Closes #19. I added two new files: 'prizes-and-sponsors.html' and 'prizes-and-sponsors.css' to include the prizes and sponsors sections on the site. The HTML file contains structured content for listing prizes and sponsor logos. The CSS file handles the styling to ensure the sections are responsive and look clean across different devices. 

Tested by manually checking the display of the new sections on various screen sizes. Everything seems to render as expected. Let me know if you want me to adjust anything.